### PR TITLE
Add Versioning & Releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
           python3 -m virtualenv -p python3 env && . env/bin/activate && pip install --upgrade pip
           curl https://raw.githubusercontent.com/WIPACrepo/keycloak-rest-services/master/keycloak_setup/institution_list.py > rest_server/databases/institution_list.py
           pip install -r rest_server/requirements.txt -r web_app/requirements.txt -r requirements-dev.txt
-          pytest -vvv --mypy --flake8 tests/unit
+          pytest -vvv tests/unit
 
   integrate:
     docker:

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -1,0 +1,23 @@
+name: Semantic Release
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Python Semantic Release
+      uses: relekang/python-semantic-release@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        # pypi_token: ${{ secrets.PYPI_TOKEN }}

--- a/rest_server/__init__.py
+++ b/rest_server/__init__.py
@@ -1,0 +1,16 @@
+"""Public init."""
+
+# version is a human-readable version number.
+
+# version_info is a four-tuple for programmatic comparison. The first
+# three numbers are the components of the version number. The fourth
+# is zero for an official release, positive for a development branch,
+# or negative for a release candidate or beta (after the base version
+# number has been incremented)
+__version__ = "2.0.0"
+version_info = (
+    int(__version__.split(".")[0]),
+    int(__version__.split(".")[1]),
+    int(__version__.split(".")[2]),
+    0,
+)

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,13 @@
 
 [tool:pytest]
 flake8-ignore = E501 W503
+
+[semantic_release]
+version_variable = web_app/__init__.py:__version__,rest_server/__init__.py:__version__
+upload_to_pypi = False
+patch_without_tag = True
+major_on_zero = False
+commit_parser = semantic_release.history.tag_parser
+minor_tag = [minor]
+fix_tag = [fix]
+branch = master

--- a/web_app/__init__.py
+++ b/web_app/__init__.py
@@ -1,0 +1,16 @@
+"""Public init."""
+
+# version is a human-readable version number.
+
+# version_info is a four-tuple for programmatic comparison. The first
+# three numbers are the components of the version number. The fourth
+# is zero for an official release, positive for a development branch,
+# or negative for a release candidate or beta (after the base version
+# number has been incremented)
+__version__ = "2.0.0"
+version_info = (
+    int(__version__.split(".")[0]),
+    int(__version__.split(".")[1]),
+    int(__version__.split(".")[2]),
+    0,
+)


### PR DESCRIPTION
Make GitHub releases and version tags.

Though Docker is used to produce the actual executables, keeping version numbers is still helpful.

closes https://github.com/WIPACrepo/mou-dashboard/issues/48