### PR TITLE
Pin `flask-oidc<2.0.0`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
 	dacite
 	dash
 	dash-bootstrap-components
-	flask-oidc
+	flask-oidc<2.0.0
 	itsdangerous==2.0.1
 	motor
 	openpyxl


### PR DESCRIPTION
`flask-oidc 2.0.0` deprecates `OVERWRITE_REDIRECT_URI`