### PR TITLE
fix auth for inst groups not in our infos

### DIFF
--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -16,7 +16,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - id: versions
-        uses: WIPACrepo/wipac-dev-py-versions-action@v2.1
+        uses: WIPACrepo/wipac-dev-py-versions-action@v2.2
+
+
+  #############################################################################
+  # LINTERS
+  #############################################################################
 
 
   flake8:
@@ -42,29 +47,62 @@ jobs:
       - uses: WIPACrepo/wipac-dev-mypy-action@v2.0
 
 
+  #############################################################################
+  # PACKAGING
+  #############################################################################
+
+
+  writable-branch-detect:
+    runs-on: ubuntu-latest
+    outputs:
+      OKAY: ${{ steps.detect.outputs.OKAY }}
+    steps:
+      - name: is this a non-dependabot branch?
+        id: detect
+        # dependabot can't access normal secrets
+        #   & don't run non-branch triggers (like tags)
+        #   & we don't want to trigger an update on PR's merge to main/master/default (which is a branch)
+        run: |
+          if [[ \
+              ${{github.actor}} != 'dependabot[bot]' && \
+              ${{github.ref_type}} == 'branch' && \
+              ${{format('refs/heads/{0}', github.event.repository.default_branch)}} != ${{github.ref}} \
+          ]]; then
+            echo "OKAY=true" >> "$GITHUB_OUTPUT"
+            echo "yes, this branch is compatible"
+          else
+            echo "OKAY=false" >> "$GITHUB_OUTPUT"
+            echo "no, this branch is incompatible"
+          fi
+
   py-setup:
+    needs: [ writable-branch-detect ]
     runs-on: ubuntu-latest
     steps:
-      # dependabot can't access normal secrets
-      #   & don't run non-branch triggers (like tags)
-      #   & we don't want to trigger an update on PR's merge to main/master/default (which is a branch)
-      # IOW: only for non-dependabot branches
-      - if: |
-          github.actor != 'dependabot[bot]' &&
-          github.ref_type == 'branch' &&
-          format('refs/heads/{0}', github.event.repository.default_branch) != github.ref
-        name: checkout (only for non-dependabot non-default branches)
+      - if: needs.writable-branch-detect.outputs.OKAY == 'true'
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-      - if: |
-          github.actor != 'dependabot[bot]' &&
-          github.ref_type == 'branch' &&
-          format('refs/heads/{0}', github.event.repository.default_branch) != github.ref
-        name: wipac-dev-py-setup-action (only for non-dependabot non-default branches)
-        uses: WIPACrepo/wipac-dev-py-setup-action@v2.9
+      - if: needs.writable-branch-detect.outputs.OKAY == 'true'
+        uses: WIPACrepo/wipac-dev-py-setup-action@v3.1
         with:
           base-keywords: WIPAC IceCube
+
+  py-dependencies:
+    needs: [ writable-branch-detect ]
+    runs-on: ubuntu-latest
+    steps:
+      - if: needs.writable-branch-detect.outputs.OKAY == 'true'
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      - if: needs.writable-branch-detect.outputs.OKAY == 'true'
+        uses: WIPACrepo/wipac-dev-py-dependencies-action@v1.1
+
+
+  #############################################################################
+  # TESTS
+  #############################################################################
 
 
   unit-tests:
@@ -217,10 +255,15 @@ jobs:
           docker logs "${{ job.services.mongo.id }}" || true
 
 
+  #############################################################################
+  # GITHUB RELEASE
+  #############################################################################
+
+
   release:
     # only run on main/master/default
     if: format('refs/heads/{0}', github.event.repository.default_branch) == github.ref
-    needs: [flake8, mypy, py-setup, unit-tests, integration-tests]
+    needs: [flake8, mypy, py-setup, py-dependencies, unit-tests, integration-tests]
     runs-on: ubuntu-latest
     concurrency: release
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,5 @@ client_secrets.json
 !dependencies*.log
 
 *secret\.json
+
+.idea

--- a/dependencies-from-Dockerfile.log
+++ b/dependencies-from-Dockerfile.log
@@ -6,67 +6,65 @@
 ########################################################################
 #  pip freeze
 ########################################################################
-aio-pika==9.3.0
-aiormq==6.7.7
-ansi2html==1.8.0
-backoff==2.2.1
-cachetools==5.3.2
-certifi==2023.7.22
+aio-pika==9.4.1
+aiormq==6.8.0
+cachetools==5.3.3
+certifi==2024.2.2
 cffi==1.16.0
 charset-normalizer==3.3.2
 click==8.1.7
 coloredlogs==15.0.1
-cryptography==41.0.5
+cryptography==42.0.5
 dacite==1.8.1
-dash==2.14.1
+dash==2.16.1
 dash-bootstrap-components==1.5.0
 dash-core-components==2.0.0
 dash-html-components==2.0.0
 dash-table==5.0.0
 Deprecated==1.2.14
-dnspython==2.4.2
+dnspython==2.6.1
 et-xmlfile==1.1.0
 Flask==2.2.5
 flask-oidc==1.4.0
 googleapis-common-protos==1.59.1
-grpcio==1.59.2
+grpcio==1.62.1
 httplib2==0.22.0
 humanfriendly==10.0
-idna==3.4
-importlib-metadata==6.8.0
+idna==3.6
+importlib-metadata==6.11.0
 itsdangerous==2.0.1
-Jinja2==3.1.2
+Jinja2==3.1.3
 ldap3==2.9.1
-MarkupSafe==2.1.3
+MarkupSafe==2.1.5
 motor==3.3.2
-multidict==6.0.4
-nest-asyncio==1.5.8
-numpy==1.26.2
+multidict==6.0.5
+nest-asyncio==1.6.0
+numpy==1.26.4
 oauth2client==4.1.3
 openpyxl==3.1.2
-opentelemetry-api==1.21.0
+opentelemetry-api==1.23.0
 opentelemetry-exporter-jaeger==1.21.0
 opentelemetry-exporter-jaeger-proto-grpc==1.21.0
 opentelemetry-exporter-jaeger-thrift==1.21.0
-opentelemetry-exporter-otlp-proto-common==1.21.0
-opentelemetry-exporter-otlp-proto-http==1.21.0
-opentelemetry-proto==1.21.0
-opentelemetry-sdk==1.21.0
-opentelemetry-semantic-conventions==0.42b0
-packaging==23.2
-pamqp==3.2.1
-pandas==2.1.3
-plotly==5.18.0
-protobuf==4.25.1
-pyasn1==0.5.0
+opentelemetry-exporter-otlp-proto-common==1.23.0
+opentelemetry-exporter-otlp-proto-http==1.23.0
+opentelemetry-proto==1.23.0
+opentelemetry-sdk==1.23.0
+opentelemetry-semantic-conventions==0.44b0
+packaging==24.0
+pamqp==3.3.0
+pandas==2.2.1
+plotly==5.20.0
+protobuf==4.25.3
+pyasn1==0.5.1
 pyasn1-modules==0.3.0
 pycparser==2.21
 PyJWT==2.8.0
-pymongo==4.6.0
-pyparsing==3.1.1
+pymongo==4.6.2
+pyparsing==3.1.2
 pypng==0.20220715.0
-python-dateutil==2.8.2
-pytz==2023.3.post1
+python-dateutil==2.9.0.post0
+pytz==2024.1
 qrcode==7.4.2
 requests==2.31.0
 requests-futures==1.0.1
@@ -75,316 +73,312 @@ rsa==4.9
 six==1.16.0
 tenacity==8.2.3
 thrift==0.16.0
-tornado==6.3.3
+tornado==6.4
 typeguard==4.1.5
-typing_extensions==4.8.0
-tzdata==2023.3
-Unidecode==1.3.7
-urllib3==2.1.0
+typing_extensions==4.10.0
+tzdata==2024.1
+Unidecode==1.3.8
+urllib3==2.2.1
 visdcc==0.0.50
 Werkzeug==2.3.8
-wipac-dev-tools==1.7.1
-wipac-keycloak-rest-services==1.4.49
+wipac-dev-tools==1.9.1
+wipac-keycloak-rest-services==1.4.66
 wipac-rest-tools==1.5.3
 wipac-telemetry==0.3.0
 wrapt==1.16.0
-yarl==1.9.2
-zipp==3.17.0
+yarl==1.9.4
+zipp==3.18.1
 ########################################################################
 #  pipdeptree
 ########################################################################
-cryptography==41.0.5
+cryptography==42.0.5
 └── cffi [required: >=1.12, installed: 1.16.0]
     └── pycparser [required: Any, installed: 2.21]
 pip==23.0.1
-pipdeptree==2.13.1
+pipdeptree==2.16.1
 rest-server-web-app-universal-utils
-├── cachetools [required: Any, installed: 5.3.2]
+├── cachetools [required: Any, installed: 5.3.3]
 ├── coloredlogs [required: Any, installed: 15.0.1]
 │   └── humanfriendly [required: >=9.1, installed: 10.0]
 ├── dacite [required: Any, installed: 1.8.1]
-├── dash [required: Any, installed: 2.14.1]
-│   ├── ansi2html [required: Any, installed: 1.8.0]
+├── dash [required: Any, installed: 2.16.1]
 │   ├── dash-core-components [required: ==2.0.0, installed: 2.0.0]
 │   ├── dash-html-components [required: ==2.0.0, installed: 2.0.0]
 │   ├── dash-table [required: ==5.0.0, installed: 5.0.0]
 │   ├── Flask [required: >=1.0.4,<3.1, installed: 2.2.5]
 │   │   ├── click [required: >=8.0, installed: 8.1.7]
 │   │   ├── itsdangerous [required: >=2.0, installed: 2.0.1]
-│   │   ├── Jinja2 [required: >=3.0, installed: 3.1.2]
-│   │   │   └── MarkupSafe [required: >=2.0, installed: 2.1.3]
-│   │   └── werkzeug [required: >=2.2.2, installed: 2.3.8]
-│   │       └── MarkupSafe [required: >=2.1.1, installed: 2.1.3]
-│   ├── importlib-metadata [required: Any, installed: 6.8.0]
-│   │   └── zipp [required: >=0.5, installed: 3.17.0]
-│   ├── nest-asyncio [required: Any, installed: 1.5.8]
-│   ├── plotly [required: >=5.0.0, installed: 5.18.0]
-│   │   ├── packaging [required: Any, installed: 23.2]
+│   │   ├── Jinja2 [required: >=3.0, installed: 3.1.3]
+│   │   │   └── MarkupSafe [required: >=2.0, installed: 2.1.5]
+│   │   └── Werkzeug [required: >=2.2.2, installed: 2.3.8]
+│   │       └── MarkupSafe [required: >=2.1.1, installed: 2.1.5]
+│   ├── importlib-metadata [required: Any, installed: 6.11.0]
+│   │   └── zipp [required: >=0.5, installed: 3.18.1]
+│   ├── nest-asyncio [required: Any, installed: 1.6.0]
+│   ├── plotly [required: >=5.0.0, installed: 5.20.0]
+│   │   ├── packaging [required: Any, installed: 24.0]
 │   │   └── tenacity [required: >=6.2.0, installed: 8.2.3]
 │   ├── requests [required: Any, installed: 2.31.0]
-│   │   ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
+│   │   ├── certifi [required: >=2017.4.17, installed: 2024.2.2]
 │   │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-│   │   ├── idna [required: >=2.5,<4, installed: 3.4]
-│   │   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
+│   │   ├── idna [required: >=2.5,<4, installed: 3.6]
+│   │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.1]
 │   ├── retrying [required: Any, installed: 1.3.4]
 │   │   └── six [required: >=1.7.0, installed: 1.16.0]
 │   ├── setuptools [required: Any, installed: 65.5.1]
-│   ├── typing-extensions [required: >=4.1.1, installed: 4.8.0]
-│   └── werkzeug [required: <3.1, installed: 2.3.8]
-│       └── MarkupSafe [required: >=2.1.1, installed: 2.1.3]
+│   ├── typing_extensions [required: >=4.1.1, installed: 4.10.0]
+│   └── Werkzeug [required: <3.1, installed: 2.3.8]
+│       └── MarkupSafe [required: >=2.1.1, installed: 2.1.5]
 ├── dash-bootstrap-components [required: Any, installed: 1.5.0]
-│   └── dash [required: >=2.0.0, installed: 2.14.1]
-│       ├── ansi2html [required: Any, installed: 1.8.0]
+│   └── dash [required: >=2.0.0, installed: 2.16.1]
 │       ├── dash-core-components [required: ==2.0.0, installed: 2.0.0]
 │       ├── dash-html-components [required: ==2.0.0, installed: 2.0.0]
 │       ├── dash-table [required: ==5.0.0, installed: 5.0.0]
 │       ├── Flask [required: >=1.0.4,<3.1, installed: 2.2.5]
 │       │   ├── click [required: >=8.0, installed: 8.1.7]
 │       │   ├── itsdangerous [required: >=2.0, installed: 2.0.1]
-│       │   ├── Jinja2 [required: >=3.0, installed: 3.1.2]
-│       │   │   └── MarkupSafe [required: >=2.0, installed: 2.1.3]
-│       │   └── werkzeug [required: >=2.2.2, installed: 2.3.8]
-│       │       └── MarkupSafe [required: >=2.1.1, installed: 2.1.3]
-│       ├── importlib-metadata [required: Any, installed: 6.8.0]
-│       │   └── zipp [required: >=0.5, installed: 3.17.0]
-│       ├── nest-asyncio [required: Any, installed: 1.5.8]
-│       ├── plotly [required: >=5.0.0, installed: 5.18.0]
-│       │   ├── packaging [required: Any, installed: 23.2]
+│       │   ├── Jinja2 [required: >=3.0, installed: 3.1.3]
+│       │   │   └── MarkupSafe [required: >=2.0, installed: 2.1.5]
+│       │   └── Werkzeug [required: >=2.2.2, installed: 2.3.8]
+│       │       └── MarkupSafe [required: >=2.1.1, installed: 2.1.5]
+│       ├── importlib-metadata [required: Any, installed: 6.11.0]
+│       │   └── zipp [required: >=0.5, installed: 3.18.1]
+│       ├── nest-asyncio [required: Any, installed: 1.6.0]
+│       ├── plotly [required: >=5.0.0, installed: 5.20.0]
+│       │   ├── packaging [required: Any, installed: 24.0]
 │       │   └── tenacity [required: >=6.2.0, installed: 8.2.3]
 │       ├── requests [required: Any, installed: 2.31.0]
-│       │   ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
+│       │   ├── certifi [required: >=2017.4.17, installed: 2024.2.2]
 │       │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-│       │   ├── idna [required: >=2.5,<4, installed: 3.4]
-│       │   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
+│       │   ├── idna [required: >=2.5,<4, installed: 3.6]
+│       │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.1]
 │       ├── retrying [required: Any, installed: 1.3.4]
 │       │   └── six [required: >=1.7.0, installed: 1.16.0]
 │       ├── setuptools [required: Any, installed: 65.5.1]
-│       ├── typing-extensions [required: >=4.1.1, installed: 4.8.0]
-│       └── werkzeug [required: <3.1, installed: 2.3.8]
-│           └── MarkupSafe [required: >=2.1.1, installed: 2.1.3]
+│       ├── typing_extensions [required: >=4.1.1, installed: 4.10.0]
+│       └── Werkzeug [required: <3.1, installed: 2.3.8]
+│           └── MarkupSafe [required: >=2.1.1, installed: 2.1.5]
 ├── Flask [required: <3, installed: 2.2.5]
 │   ├── click [required: >=8.0, installed: 8.1.7]
 │   ├── itsdangerous [required: >=2.0, installed: 2.0.1]
-│   ├── Jinja2 [required: >=3.0, installed: 3.1.2]
-│   │   └── MarkupSafe [required: >=2.0, installed: 2.1.3]
-│   └── werkzeug [required: >=2.2.2, installed: 2.3.8]
-│       └── MarkupSafe [required: >=2.1.1, installed: 2.1.3]
+│   ├── Jinja2 [required: >=3.0, installed: 3.1.3]
+│   │   └── MarkupSafe [required: >=2.0, installed: 2.1.5]
+│   └── Werkzeug [required: >=2.2.2, installed: 2.3.8]
+│       └── MarkupSafe [required: >=2.1.1, installed: 2.1.5]
 ├── flask-oidc [required: <2.0.0, installed: 1.4.0]
 │   ├── Flask [required: Any, installed: 2.2.5]
 │   │   ├── click [required: >=8.0, installed: 8.1.7]
 │   │   ├── itsdangerous [required: >=2.0, installed: 2.0.1]
-│   │   ├── Jinja2 [required: >=3.0, installed: 3.1.2]
-│   │   │   └── MarkupSafe [required: >=2.0, installed: 2.1.3]
-│   │   └── werkzeug [required: >=2.2.2, installed: 2.3.8]
-│   │       └── MarkupSafe [required: >=2.1.1, installed: 2.1.3]
+│   │   ├── Jinja2 [required: >=3.0, installed: 3.1.3]
+│   │   │   └── MarkupSafe [required: >=2.0, installed: 2.1.5]
+│   │   └── Werkzeug [required: >=2.2.2, installed: 2.3.8]
+│   │       └── MarkupSafe [required: >=2.1.1, installed: 2.1.5]
 │   ├── itsdangerous [required: Any, installed: 2.0.1]
 │   ├── oauth2client [required: Any, installed: 4.1.3]
 │   │   ├── httplib2 [required: >=0.9.1, installed: 0.22.0]
-│   │   │   └── pyparsing [required: >=2.4.2,<4,!=3.0.3,!=3.0.2,!=3.0.1,!=3.0.0, installed: 3.1.1]
-│   │   ├── pyasn1 [required: >=0.1.7, installed: 0.5.0]
+│   │   │   └── pyparsing [required: >=2.4.2,<4,!=3.0.3,!=3.0.2,!=3.0.1,!=3.0.0, installed: 3.1.2]
+│   │   ├── pyasn1 [required: >=0.1.7, installed: 0.5.1]
 │   │   ├── pyasn1-modules [required: >=0.0.5, installed: 0.3.0]
-│   │   │   └── pyasn1 [required: >=0.4.6,<0.6.0, installed: 0.5.0]
+│   │   │   └── pyasn1 [required: >=0.4.6,<0.6.0, installed: 0.5.1]
 │   │   ├── rsa [required: >=3.1.4, installed: 4.9]
-│   │   │   └── pyasn1 [required: >=0.1.3, installed: 0.5.0]
+│   │   │   └── pyasn1 [required: >=0.1.3, installed: 0.5.1]
 │   │   └── six [required: >=1.6.1, installed: 1.16.0]
 │   └── six [required: Any, installed: 1.16.0]
 ├── itsdangerous [required: ==2.0.1, installed: 2.0.1]
 ├── motor [required: Any, installed: 3.3.2]
-│   └── pymongo [required: >=4.5,<5, installed: 4.6.0]
-│       └── dnspython [required: >=1.16.0,<3.0.0, installed: 2.4.2]
+│   └── pymongo [required: >=4.5,<5, installed: 4.6.2]
+│       └── dnspython [required: >=1.16.0,<3.0.0, installed: 2.6.1]
 ├── openpyxl [required: Any, installed: 3.1.2]
 │   └── et-xmlfile [required: Any, installed: 1.1.0]
-├── pandas [required: Any, installed: 2.1.3]
-│   ├── numpy [required: >=1.22.4,<2, installed: 1.26.2]
-│   ├── python-dateutil [required: >=2.8.2, installed: 2.8.2]
+├── pandas [required: Any, installed: 2.2.1]
+│   ├── numpy [required: >=1.22.4,<2, installed: 1.26.4]
+│   ├── python-dateutil [required: >=2.8.2, installed: 2.9.0.post0]
 │   │   └── six [required: >=1.5, installed: 1.16.0]
-│   ├── pytz [required: >=2020.1, installed: 2023.3.post1]
-│   └── tzdata [required: >=2022.1, installed: 2023.3]
-├── plotly [required: Any, installed: 5.18.0]
-│   ├── packaging [required: Any, installed: 23.2]
+│   ├── pytz [required: >=2020.1, installed: 2024.1]
+│   └── tzdata [required: >=2022.7, installed: 2024.1]
+├── plotly [required: Any, installed: 5.20.0]
+│   ├── packaging [required: Any, installed: 24.0]
 │   └── tenacity [required: >=6.2.0, installed: 8.2.3]
-├── pymongo [required: Any, installed: 4.6.0]
-│   └── dnspython [required: >=1.16.0,<3.0.0, installed: 2.4.2]
-├── python-dateutil [required: Any, installed: 2.8.2]
+├── pymongo [required: Any, installed: 4.6.2]
+│   └── dnspython [required: >=1.16.0,<3.0.0, installed: 2.6.1]
+├── python-dateutil [required: Any, installed: 2.9.0.post0]
 │   └── six [required: >=1.5, installed: 1.16.0]
 ├── requests [required: Any, installed: 2.31.0]
-│   ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
+│   ├── certifi [required: >=2017.4.17, installed: 2024.2.2]
 │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-│   ├── idna [required: >=2.5,<4, installed: 3.4]
-│   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
-├── tornado [required: Any, installed: 6.3.3]
+│   ├── idna [required: >=2.5,<4, installed: 3.6]
+│   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.1]
+├── tornado [required: Any, installed: 6.4]
 ├── typeguard [required: Any, installed: 4.1.5]
-│   └── typing-extensions [required: >=4.7.0, installed: 4.8.0]
+│   └── typing_extensions [required: >=4.7.0, installed: 4.10.0]
 ├── visdcc [required: Any, installed: 0.0.50]
-├── werkzeug [required: <3, installed: 2.3.8]
-│   └── MarkupSafe [required: >=2.1.1, installed: 2.1.3]
-├── wipac-keycloak-rest-services [required: Any, installed: 1.4.49]
-│   ├── aio-pika [required: Any, installed: 9.3.0]
-│   │   ├── aiormq [required: >=6.7.7,<6.8.0, installed: 6.7.7]
-│   │   │   ├── pamqp [required: ==3.2.1, installed: 3.2.1]
-│   │   │   └── yarl [required: Any, installed: 1.9.2]
-│   │   │       ├── idna [required: >=2.0, installed: 3.4]
-│   │   │       └── multidict [required: >=4.0, installed: 6.0.4]
-│   │   └── yarl [required: Any, installed: 1.9.2]
-│   │       ├── idna [required: >=2.0, installed: 3.4]
-│   │       └── multidict [required: >=4.0, installed: 6.0.4]
+├── Werkzeug [required: <3, installed: 2.3.8]
+│   └── MarkupSafe [required: >=2.1.1, installed: 2.1.5]
+├── wipac-keycloak-rest-services [required: Any, installed: 1.4.66]
+│   ├── aio-pika [required: Any, installed: 9.4.1]
+│   │   ├── aiormq [required: >=6.8.0,<6.9.0, installed: 6.8.0]
+│   │   │   ├── pamqp [required: ==3.3.0, installed: 3.3.0]
+│   │   │   └── yarl [required: Any, installed: 1.9.4]
+│   │   │       ├── idna [required: >=2.0, installed: 3.6]
+│   │   │       └── multidict [required: >=4.0, installed: 6.0.5]
+│   │   └── yarl [required: Any, installed: 1.9.4]
+│   │       ├── idna [required: >=2.0, installed: 3.6]
+│   │       └── multidict [required: >=4.0, installed: 6.0.5]
 │   ├── ldap3 [required: Any, installed: 2.9.1]
-│   │   └── pyasn1 [required: >=0.4.6, installed: 0.5.0]
+│   │   └── pyasn1 [required: >=0.4.6, installed: 0.5.1]
 │   ├── motor [required: Any, installed: 3.3.2]
-│   │   └── pymongo [required: >=4.5,<5, installed: 4.6.0]
-│   │       └── dnspython [required: >=1.16.0,<3.0.0, installed: 2.4.2]
+│   │   └── pymongo [required: >=4.5,<5, installed: 4.6.2]
+│   │       └── dnspython [required: >=1.16.0,<3.0.0, installed: 2.6.1]
 │   ├── requests [required: Any, installed: 2.31.0]
-│   │   ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
+│   │   ├── certifi [required: >=2017.4.17, installed: 2024.2.2]
 │   │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-│   │   ├── idna [required: >=2.5,<4, installed: 3.4]
-│   │   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
-│   ├── Unidecode [required: Any, installed: 1.3.7]
-│   ├── wipac-dev-tools [required: Any, installed: 1.7.1]
+│   │   ├── idna [required: >=2.5,<4, installed: 3.6]
+│   │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.1]
+│   ├── Unidecode [required: Any, installed: 1.3.8]
+│   ├── wipac-dev-tools [required: Any, installed: 1.9.1]
 │   │   ├── requests [required: Any, installed: 2.31.0]
-│   │   │   ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
+│   │   │   ├── certifi [required: >=2017.4.17, installed: 2024.2.2]
 │   │   │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-│   │   │   ├── idna [required: >=2.5,<4, installed: 3.4]
-│   │   │   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
-│   │   └── typing-extensions [required: Any, installed: 4.8.0]
+│   │   │   ├── idna [required: >=2.5,<4, installed: 3.6]
+│   │   │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.1]
+│   │   └── typing_extensions [required: Any, installed: 4.10.0]
 │   └── wipac-rest-tools [required: Any, installed: 1.5.3]
-│       ├── cachetools [required: Any, installed: 5.3.2]
+│       ├── cachetools [required: Any, installed: 5.3.3]
 │       ├── PyJWT [required: !=2.6.0, installed: 2.8.0]
 │       ├── qrcode [required: Any, installed: 7.4.2]
 │       │   ├── pypng [required: Any, installed: 0.20220715.0]
-│       │   └── typing-extensions [required: Any, installed: 4.8.0]
+│       │   └── typing_extensions [required: Any, installed: 4.10.0]
 │       ├── requests [required: Any, installed: 2.31.0]
-│       │   ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
+│       │   ├── certifi [required: >=2017.4.17, installed: 2024.2.2]
 │       │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-│       │   ├── idna [required: >=2.5,<4, installed: 3.4]
-│       │   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
+│       │   ├── idna [required: >=2.5,<4, installed: 3.6]
+│       │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.1]
 │       ├── requests-futures [required: Any, installed: 1.0.1]
 │       │   └── requests [required: >=1.2.0, installed: 2.31.0]
-│       │       ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
+│       │       ├── certifi [required: >=2017.4.17, installed: 2024.2.2]
 │       │       ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-│       │       ├── idna [required: >=2.5,<4, installed: 3.4]
-│       │       └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
-│       ├── tornado [required: Any, installed: 6.3.3]
-│       ├── urllib3 [required: >=2.0.4, installed: 2.1.0]
-│       └── wipac-dev-tools [required: Any, installed: 1.7.1]
+│       │       ├── idna [required: >=2.5,<4, installed: 3.6]
+│       │       └── urllib3 [required: >=1.21.1,<3, installed: 2.2.1]
+│       ├── tornado [required: Any, installed: 6.4]
+│       ├── urllib3 [required: >=2.0.4, installed: 2.2.1]
+│       └── wipac-dev-tools [required: Any, installed: 1.9.1]
 │           ├── requests [required: Any, installed: 2.31.0]
-│           │   ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
+│           │   ├── certifi [required: >=2017.4.17, installed: 2024.2.2]
 │           │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-│           │   ├── idna [required: >=2.5,<4, installed: 3.4]
-│           │   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
-│           └── typing-extensions [required: Any, installed: 4.8.0]
+│           │   ├── idna [required: >=2.5,<4, installed: 3.6]
+│           │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.1]
+│           └── typing_extensions [required: Any, installed: 4.10.0]
 └── wipac-rest-tools [required: <1.6.0, installed: 1.5.3]
-    ├── cachetools [required: Any, installed: 5.3.2]
+    ├── cachetools [required: Any, installed: 5.3.3]
     ├── PyJWT [required: !=2.6.0, installed: 2.8.0]
     ├── qrcode [required: Any, installed: 7.4.2]
     │   ├── pypng [required: Any, installed: 0.20220715.0]
-    │   └── typing-extensions [required: Any, installed: 4.8.0]
+    │   └── typing_extensions [required: Any, installed: 4.10.0]
     ├── requests [required: Any, installed: 2.31.0]
-    │   ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
+    │   ├── certifi [required: >=2017.4.17, installed: 2024.2.2]
     │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-    │   ├── idna [required: >=2.5,<4, installed: 3.4]
-    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
+    │   ├── idna [required: >=2.5,<4, installed: 3.6]
+    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.1]
     ├── requests-futures [required: Any, installed: 1.0.1]
     │   └── requests [required: >=1.2.0, installed: 2.31.0]
-    │       ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
+    │       ├── certifi [required: >=2017.4.17, installed: 2024.2.2]
     │       ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-    │       ├── idna [required: >=2.5,<4, installed: 3.4]
-    │       └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
-    ├── tornado [required: Any, installed: 6.3.3]
-    ├── urllib3 [required: >=2.0.4, installed: 2.1.0]
-    └── wipac-dev-tools [required: Any, installed: 1.7.1]
+    │       ├── idna [required: >=2.5,<4, installed: 3.6]
+    │       └── urllib3 [required: >=1.21.1,<3, installed: 2.2.1]
+    ├── tornado [required: Any, installed: 6.4]
+    ├── urllib3 [required: >=2.0.4, installed: 2.2.1]
+    └── wipac-dev-tools [required: Any, installed: 1.9.1]
         ├── requests [required: Any, installed: 2.31.0]
-        │   ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
+        │   ├── certifi [required: >=2017.4.17, installed: 2024.2.2]
         │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-        │   ├── idna [required: >=2.5,<4, installed: 3.4]
-        │   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
-        └── typing-extensions [required: Any, installed: 4.8.0]
-wheel==0.41.3
+        │   ├── idna [required: >=2.5,<4, installed: 3.6]
+        │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.1]
+        └── typing_extensions [required: Any, installed: 4.10.0]
+wheel==0.43.0
 wipac-telemetry==0.3.0
 ├── coloredlogs [required: Any, installed: 15.0.1]
 │   └── humanfriendly [required: >=9.1, installed: 10.0]
-├── opentelemetry-api [required: Any, installed: 1.21.0]
+├── opentelemetry-api [required: Any, installed: 1.23.0]
 │   ├── Deprecated [required: >=1.2.6, installed: 1.2.14]
 │   │   └── wrapt [required: >=1.10,<2, installed: 1.16.0]
-│   └── importlib-metadata [required: >=6.0,<7.0, installed: 6.8.0]
-│       └── zipp [required: >=0.5, installed: 3.17.0]
+│   └── importlib-metadata [required: >=6.0,<7.0, installed: 6.11.0]
+│       └── zipp [required: >=0.5, installed: 3.18.1]
 ├── opentelemetry-exporter-jaeger [required: Any, installed: 1.21.0]
 │   ├── opentelemetry-exporter-jaeger-proto-grpc [required: ==1.21.0, installed: 1.21.0]
 │   │   ├── googleapis-common-protos [required: ~=1.52,<1.60.0, installed: 1.59.1]
-│   │   │   └── protobuf [required: >=3.19.5,<5.0.0.dev0,!=4.21.5,!=4.21.4,!=4.21.3,!=4.21.2,!=4.21.1,!=3.20.1,!=3.20.0, installed: 4.25.1]
-│   │   ├── grpcio [required: >=1.0.0,<2.0.0, installed: 1.59.2]
-│   │   ├── opentelemetry-api [required: ~=1.3, installed: 1.21.0]
+│   │   │   └── protobuf [required: >=3.19.5,<5.0.0.dev0,!=4.21.5,!=4.21.4,!=4.21.3,!=4.21.2,!=4.21.1,!=3.20.1,!=3.20.0, installed: 4.25.3]
+│   │   ├── grpcio [required: >=1.0.0,<2.0.0, installed: 1.62.1]
+│   │   ├── opentelemetry-api [required: ~=1.3, installed: 1.23.0]
 │   │   │   ├── Deprecated [required: >=1.2.6, installed: 1.2.14]
 │   │   │   │   └── wrapt [required: >=1.10,<2, installed: 1.16.0]
-│   │   │   └── importlib-metadata [required: >=6.0,<7.0, installed: 6.8.0]
-│   │   │       └── zipp [required: >=0.5, installed: 3.17.0]
-│   │   └── opentelemetry-sdk [required: ~=1.11, installed: 1.21.0]
-│   │       ├── opentelemetry-api [required: ==1.21.0, installed: 1.21.0]
+│   │   │   └── importlib-metadata [required: >=6.0,<7.0, installed: 6.11.0]
+│   │   │       └── zipp [required: >=0.5, installed: 3.18.1]
+│   │   └── opentelemetry-sdk [required: ~=1.11, installed: 1.23.0]
+│   │       ├── opentelemetry-api [required: ==1.23.0, installed: 1.23.0]
 │   │       │   ├── Deprecated [required: >=1.2.6, installed: 1.2.14]
 │   │       │   │   └── wrapt [required: >=1.10,<2, installed: 1.16.0]
-│   │       │   └── importlib-metadata [required: >=6.0,<7.0, installed: 6.8.0]
-│   │       │       └── zipp [required: >=0.5, installed: 3.17.0]
-│   │       ├── opentelemetry-semantic-conventions [required: ==0.42b0, installed: 0.42b0]
-│   │       └── typing-extensions [required: >=3.7.4, installed: 4.8.0]
+│   │       │   └── importlib-metadata [required: >=6.0,<7.0, installed: 6.11.0]
+│   │       │       └── zipp [required: >=0.5, installed: 3.18.1]
+│   │       ├── opentelemetry-semantic-conventions [required: ==0.44b0, installed: 0.44b0]
+│   │       └── typing_extensions [required: >=3.7.4, installed: 4.10.0]
 │   └── opentelemetry-exporter-jaeger-thrift [required: ==1.21.0, installed: 1.21.0]
-│       ├── opentelemetry-api [required: ~=1.3, installed: 1.21.0]
+│       ├── opentelemetry-api [required: ~=1.3, installed: 1.23.0]
 │       │   ├── Deprecated [required: >=1.2.6, installed: 1.2.14]
 │       │   │   └── wrapt [required: >=1.10,<2, installed: 1.16.0]
-│       │   └── importlib-metadata [required: >=6.0,<7.0, installed: 6.8.0]
-│       │       └── zipp [required: >=0.5, installed: 3.17.0]
-│       ├── opentelemetry-sdk [required: ~=1.11, installed: 1.21.0]
-│       │   ├── opentelemetry-api [required: ==1.21.0, installed: 1.21.0]
+│       │   └── importlib-metadata [required: >=6.0,<7.0, installed: 6.11.0]
+│       │       └── zipp [required: >=0.5, installed: 3.18.1]
+│       ├── opentelemetry-sdk [required: ~=1.11, installed: 1.23.0]
+│       │   ├── opentelemetry-api [required: ==1.23.0, installed: 1.23.0]
 │       │   │   ├── Deprecated [required: >=1.2.6, installed: 1.2.14]
 │       │   │   │   └── wrapt [required: >=1.10,<2, installed: 1.16.0]
-│       │   │   └── importlib-metadata [required: >=6.0,<7.0, installed: 6.8.0]
-│       │   │       └── zipp [required: >=0.5, installed: 3.17.0]
-│       │   ├── opentelemetry-semantic-conventions [required: ==0.42b0, installed: 0.42b0]
-│       │   └── typing-extensions [required: >=3.7.4, installed: 4.8.0]
+│       │   │   └── importlib-metadata [required: >=6.0,<7.0, installed: 6.11.0]
+│       │   │       └── zipp [required: >=0.5, installed: 3.18.1]
+│       │   ├── opentelemetry-semantic-conventions [required: ==0.44b0, installed: 0.44b0]
+│       │   └── typing_extensions [required: >=3.7.4, installed: 4.10.0]
 │       └── thrift [required: >=0.10.0, installed: 0.16.0]
 │           └── six [required: >=1.7.2, installed: 1.16.0]
-├── opentelemetry-exporter-otlp-proto-http [required: Any, installed: 1.21.0]
-│   ├── backoff [required: >=1.10.0,<3.0.0, installed: 2.2.1]
+├── opentelemetry-exporter-otlp-proto-http [required: Any, installed: 1.23.0]
 │   ├── Deprecated [required: >=1.2.6, installed: 1.2.14]
 │   │   └── wrapt [required: >=1.10,<2, installed: 1.16.0]
 │   ├── googleapis-common-protos [required: ~=1.52, installed: 1.59.1]
-│   │   └── protobuf [required: >=3.19.5,<5.0.0.dev0,!=4.21.5,!=4.21.4,!=4.21.3,!=4.21.2,!=4.21.1,!=3.20.1,!=3.20.0, installed: 4.25.1]
-│   ├── opentelemetry-api [required: ~=1.15, installed: 1.21.0]
+│   │   └── protobuf [required: >=3.19.5,<5.0.0.dev0,!=4.21.5,!=4.21.4,!=4.21.3,!=4.21.2,!=4.21.1,!=3.20.1,!=3.20.0, installed: 4.25.3]
+│   ├── opentelemetry-api [required: ~=1.15, installed: 1.23.0]
 │   │   ├── Deprecated [required: >=1.2.6, installed: 1.2.14]
 │   │   │   └── wrapt [required: >=1.10,<2, installed: 1.16.0]
-│   │   └── importlib-metadata [required: >=6.0,<7.0, installed: 6.8.0]
-│   │       └── zipp [required: >=0.5, installed: 3.17.0]
-│   ├── opentelemetry-exporter-otlp-proto-common [required: ==1.21.0, installed: 1.21.0]
-│   │   ├── backoff [required: >=1.10.0,<3.0.0, installed: 2.2.1]
-│   │   └── opentelemetry-proto [required: ==1.21.0, installed: 1.21.0]
-│   │       └── protobuf [required: >=3.19,<5.0, installed: 4.25.1]
-│   ├── opentelemetry-proto [required: ==1.21.0, installed: 1.21.0]
-│   │   └── protobuf [required: >=3.19,<5.0, installed: 4.25.1]
-│   ├── opentelemetry-sdk [required: ~=1.21.0, installed: 1.21.0]
-│   │   ├── opentelemetry-api [required: ==1.21.0, installed: 1.21.0]
+│   │   └── importlib-metadata [required: >=6.0,<7.0, installed: 6.11.0]
+│   │       └── zipp [required: >=0.5, installed: 3.18.1]
+│   ├── opentelemetry-exporter-otlp-proto-common [required: ==1.23.0, installed: 1.23.0]
+│   │   └── opentelemetry-proto [required: ==1.23.0, installed: 1.23.0]
+│   │       └── protobuf [required: >=3.19,<5.0, installed: 4.25.3]
+│   ├── opentelemetry-proto [required: ==1.23.0, installed: 1.23.0]
+│   │   └── protobuf [required: >=3.19,<5.0, installed: 4.25.3]
+│   ├── opentelemetry-sdk [required: ~=1.23.0, installed: 1.23.0]
+│   │   ├── opentelemetry-api [required: ==1.23.0, installed: 1.23.0]
 │   │   │   ├── Deprecated [required: >=1.2.6, installed: 1.2.14]
 │   │   │   │   └── wrapt [required: >=1.10,<2, installed: 1.16.0]
-│   │   │   └── importlib-metadata [required: >=6.0,<7.0, installed: 6.8.0]
-│   │   │       └── zipp [required: >=0.5, installed: 3.17.0]
-│   │   ├── opentelemetry-semantic-conventions [required: ==0.42b0, installed: 0.42b0]
-│   │   └── typing-extensions [required: >=3.7.4, installed: 4.8.0]
+│   │   │   └── importlib-metadata [required: >=6.0,<7.0, installed: 6.11.0]
+│   │   │       └── zipp [required: >=0.5, installed: 3.18.1]
+│   │   ├── opentelemetry-semantic-conventions [required: ==0.44b0, installed: 0.44b0]
+│   │   └── typing_extensions [required: >=3.7.4, installed: 4.10.0]
 │   └── requests [required: ~=2.7, installed: 2.31.0]
-│       ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
+│       ├── certifi [required: >=2017.4.17, installed: 2024.2.2]
 │       ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-│       ├── idna [required: >=2.5,<4, installed: 3.4]
-│       └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
-├── opentelemetry-sdk [required: Any, installed: 1.21.0]
-│   ├── opentelemetry-api [required: ==1.21.0, installed: 1.21.0]
+│       ├── idna [required: >=2.5,<4, installed: 3.6]
+│       └── urllib3 [required: >=1.21.1,<3, installed: 2.2.1]
+├── opentelemetry-sdk [required: Any, installed: 1.23.0]
+│   ├── opentelemetry-api [required: ==1.23.0, installed: 1.23.0]
 │   │   ├── Deprecated [required: >=1.2.6, installed: 1.2.14]
 │   │   │   └── wrapt [required: >=1.10,<2, installed: 1.16.0]
-│   │   └── importlib-metadata [required: >=6.0,<7.0, installed: 6.8.0]
-│   │       └── zipp [required: >=0.5, installed: 3.17.0]
-│   ├── opentelemetry-semantic-conventions [required: ==0.42b0, installed: 0.42b0]
-│   └── typing-extensions [required: >=3.7.4, installed: 4.8.0]
-├── protobuf [required: Any, installed: 4.25.1]
-├── typing-extensions [required: Any, installed: 4.8.0]
-└── wipac-dev-tools [required: Any, installed: 1.7.1]
+│   │   └── importlib-metadata [required: >=6.0,<7.0, installed: 6.11.0]
+│   │       └── zipp [required: >=0.5, installed: 3.18.1]
+│   ├── opentelemetry-semantic-conventions [required: ==0.44b0, installed: 0.44b0]
+│   └── typing_extensions [required: >=3.7.4, installed: 4.10.0]
+├── protobuf [required: Any, installed: 4.25.3]
+├── typing_extensions [required: Any, installed: 4.10.0]
+└── wipac-dev-tools [required: Any, installed: 1.9.1]
     ├── requests [required: Any, installed: 2.31.0]
-    │   ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
+    │   ├── certifi [required: >=2017.4.17, installed: 2024.2.2]
     │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-    │   ├── idna [required: >=2.5,<4, installed: 3.4]
-    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
-    └── typing-extensions [required: Any, installed: 4.8.0]
+    │   ├── idna [required: >=2.5,<4, installed: 3.6]
+    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.1]
+    └── typing_extensions [required: Any, installed: 4.10.0]

--- a/tests/integration/test_web_data_source.py
+++ b/tests/integration/test_web_data_source.py
@@ -15,7 +15,7 @@ from web_app.data_source import table_config as tc
 def clear_all_cachetools_func_caches() -> Iterator[None]:
     """Clear all `cachetools.func` caches, everywhere"""
     yield
-    connections._cached_get_institutions_infos.cache_clear()  # type: ignore[attr-defined]
+    connections._cached_get_todays_institutions_infos.cache_clear()  # type: ignore[attr-defined]
     tc.TableConfigParser._cached_get_configs.cache_clear()  # type: ignore[attr-defined]
     web_app.data_source.connections.CurrentUser._cached_get_info.cache_clear()  # type: ignore[attr-defined]
 

--- a/tests/unit/test_web_app.py
+++ b/tests/unit/test_web_app.py
@@ -27,7 +27,7 @@ WBS = "mo"
 def clear_all_cachetools_func_caches() -> Iterator[None]:
     """Clear all `cachetools.func` caches, everywhere."""
     yield
-    connections._cached_get_institutions_infos.cache_clear()  # type: ignore[attr-defined]
+    connections._cached_get_todays_institutions_infos.cache_clear()  # type: ignore[attr-defined]
     tc.TableConfigParser._cached_get_configs.cache_clear()  # type: ignore[attr-defined]
     web_app.data_source.connections.CurrentUser._cached_get_info.cache_clear()  # type: ignore[attr-defined]
 

--- a/web_app/contents/institution_callbacks.py
+++ b/web_app/contents/institution_callbacks.py
@@ -375,7 +375,7 @@ def to_pull_institution_values(
                 "value": short_name,
                 # "disabled": not info.has_mou,
             }
-            for short_name, info in connections.get_institutions_infos().items()
+            for short_name, info in connections.get_todays_institutions_infos().items()
         ]
     else:
         output.ddown_inst_opts = [  # only include the user's institution(s)
@@ -384,7 +384,7 @@ def to_pull_institution_values(
                 "value": short_name,
                 # "disabled": not info.has_mou,
             }
-            for short_name, info in connections.get_institutions_infos().items()
+            for short_name, info in connections.get_todays_institutions_infos().items()
             if short_name in CurrentUser.get_institutions()
         ]
     output.ddown_inst_opts = sorted(output.ddown_inst_opts, key=lambda d: d["label"])

--- a/web_app/contents/wbs_generic_admin_callbacks.py
+++ b/web_app/contents/wbs_generic_admin_callbacks.py
@@ -185,7 +185,7 @@ def summarize(
     except DataSourceException:
         return [], [], []
 
-    insts_infos = connections.get_institutions_infos()
+    insts_infos = connections.get_todays_institutions_infos()
 
     def _sum_it(_inst: str, _l2: str = "") -> float:
         return float(

--- a/web_app/data_source/connections.py
+++ b/web_app/data_source/connections.py
@@ -209,6 +209,8 @@ class CurrentUser:
         infos = get_institutions_infos()
         editable_insts = []
         for short_name in group_insts:
+            if short_name not in infos:
+                continue
             if not infos[short_name].has_mou:
                 logging.error(
                     f"User ({CurrentUser.get_username()}) belongs to {short_name},"

--- a/web_app/data_source/connections.py
+++ b/web_app/data_source/connections.py
@@ -220,6 +220,7 @@ class CurrentUser:
                     f"User ({CurrentUser.get_username()}) belongs to {inst_short_name},"
                     " but institution does not have an MOU (has_mou=false)"
                 )
+                continue  # technically not needed since this inst couldn't be selected to begin with
             user_mou_insts.append(inst_short_name)
 
         return user_mou_insts

--- a/web_app/data_source/connections.py
+++ b/web_app/data_source/connections.py
@@ -87,15 +87,15 @@ def mou_request(method: str, url: str, body: Any = None) -> dict[str, Any]:
 
 
 @cachetools.func.ttl_cache(ttl=MAX_CACHE_MINS * 60)
-def _cached_get_institutions_infos() -> dict[str, uut.Institution]:
+def _cached_get_todays_institutions_infos() -> dict[str, uut.Institution]:
     logging.warning("Cache Miss: _cached_get_institutions_infos()")
     resp = cast(dict[str, dict[str, Any]], mou_request("GET", "/institution/today"))
     return {k: uut.Institution(**v) for k, v in resp.items()}
 
 
-def get_institutions_infos() -> dict[str, uut.Institution]:
-    """Get a dict of all institutions with their info."""
-    return _cached_get_institutions_infos()
+def get_todays_institutions_infos() -> dict[str, uut.Institution]:
+    """Get a dict of all institutions with their info, accurate as of today."""
+    return _cached_get_todays_institutions_infos()
 
 
 #
@@ -197,28 +197,28 @@ class CurrentUser:
         # "/institutions/IceCube/UW-Madison/_admin" -> "UW-Madison"
         # "/institutions/IceCube-Gen2/UW-Madison/_admin" -> "UW-Madison"
 
-        group_insts = set()
+        user_insts = set()
         for user_group in CurrentUser._get_info().groups:
             pattern = (
                 r"/institutions/[^/]+/(?P<inst>[^/]+)/(mou-dashboard-editor|_admin)$"
             )
             if m := re.match(pattern, user_group):
-                group_insts.add(m.groupdict()["inst"])
+                user_insts.add(m.groupdict()["inst"])
 
         # now, check if each of the institutions has an mou
-        infos = get_institutions_infos()
-        editable_insts = []
-        for short_name in group_insts:
-            if short_name not in infos:
+        all_insts_infos = get_todays_institutions_infos()
+        user_mou_insts = []
+        for inst_short_name in user_insts:
+            if inst_short_name not in all_insts_infos:
                 continue
-            if not infos[short_name].has_mou:
+            if not all_insts_infos[inst_short_name].has_mou:
                 logging.error(
-                    f"User ({CurrentUser.get_username()}) belongs to {short_name},"
+                    f"User ({CurrentUser.get_username()}) belongs to {inst_short_name},"
                     " but institution does not have an MOU (has_mou=false)"
                 )
-            editable_insts.append(short_name)
+            user_mou_insts.append(inst_short_name)
 
-        return editable_insts
+        return user_mou_insts
 
     @staticmethod
     def get_access_token() -> str:

--- a/web_app/data_source/connections.py
+++ b/web_app/data_source/connections.py
@@ -210,6 +210,10 @@ class CurrentUser:
         user_mou_insts = []
         for inst_short_name in user_insts:
             if inst_short_name not in all_insts_infos:
+                logging.error(
+                    f"User ({CurrentUser.get_username()}) belongs to {inst_short_name},"
+                    " but institution is not in today's list of institutions."
+                )
                 continue
             if not all_insts_infos[inst_short_name].has_mou:
                 logging.error(

--- a/web_app/utils/dash_utils.py
+++ b/web_app/utils/dash_utils.py
@@ -172,7 +172,7 @@ def user_viewing_wrong_inst(urlpath: str) -> bool:
     Assumes the user is logged in.
     """
     if CurrentUser.is_admin():
-        all_insts = list(connections.get_institutions_infos().keys())
+        all_insts = list(connections.get_todays_institutions_infos().keys())
         return get_inst(urlpath) not in all_insts + [""]
     else:
         return get_inst(urlpath) not in CurrentUser.get_institutions()


### PR DESCRIPTION
Bug with groups that don't have the mou attribute at all.  I *think* this fixes it?

```
File "/home/app/.local/lib/python3.10/site-packages/dash/_callback.py", line 442, in add_context
output_value = func(*func_args, **func_kwargs) # %% callback invoked %%
File "/home/app/web_app/contents/institution_callbacks.py", line 287, in select_institution_value
_select_institution_value_dc(
File "/home/app/web_app/contents/institution_callbacks.py", line 299, in _select_institution_value_dc
f"'{du.triggered()}' -> select_institution_value() ({state.s_urlpath=} {state.s_snap_ts=} {CurrentUser.get_summary()=})"
File "/home/app/web_app/data_source/connections.py", line 145, in get_summary
"is_authenticated": CurrentUser.is_loggedin_with_permissions(),
File "/home/app/web_app/data_source/connections.py", line 169, in is_loggedin_with_permissions
if CurrentUser.get_institutions():
File "/home/app/web_app/data_source/connections.py", line 212, in get_institutions
if not infos[short_name].has_mou:
KeyError: 'WashU-StLouis'
```